### PR TITLE
provide fallback when polylines are not supported by turf

### DIFF
--- a/app/components/Stats/searchFeatures.js
+++ b/app/components/Stats/searchFeatures.js
@@ -67,11 +67,20 @@ function getRegionTiles(region, zoom) {
     }
   }
   // drop tiles that are actually outside the region
-  tiles = tiles.filter(tile =>
-    intersect(
-      bboxPolygon(merc.bbox(tile.x, tile.y, tile.zoom)),
-      region
-    ) !== undefined
+
+  tiles = tiles.filter(tile => {
+
+    const bboxPoly = bboxPolygon(merc.bbox(tile.x, tile.y, tile.zoom))
+    try {
+      return intersect(
+        bboxPoly,
+        region
+      )
+    } catch(e) {
+      console.warn(e)
+      return true
+    }
+  }
   )
   return tiles
 }


### PR DESCRIPTION
Turf has a known issues with certain geometries, see 
https://github.com/Turfjs/turf/issues/297

This avoids having Stats crashing when that happens (in which case it might use more tiles than needed to render stats for a given polygon)